### PR TITLE
Make sure that the digital clock is properly centered

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -58,5 +58,5 @@ html {
 .digital-clock {
   font-size: 2em;
   margin: auto;
-  max-width: 5em;
+  text-align: center;
 }


### PR DESCRIPTION
I noticed that the digital clock had a fixed width (smaller than the set theory clock) and, consequently, on some displays, the digital clock was not centered.

I just slightly changed the CSS to make sure that the digital clock is properly centered below the set theory clock.

Hope this helps.